### PR TITLE
Ensured scrolling would not be interrupted by other controls

### DIFF
--- a/Cheesebaron.HorizontalListView/HorizontalListView.cs
+++ b/Cheesebaron.HorizontalListView/HorizontalListView.cs
@@ -425,6 +425,7 @@ namespace Cheesebaron.HorizontalListView
 
             public override bool OnScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY)
             {
+                _horizontalListView.RequestDisallowInterceptTouchEvent(true);
                 _horizontalListView._nextX += (int)distanceX;
                 _horizontalListView.RequestLayout();
 


### PR DESCRIPTION
When the `HorizontalListview` is added to a vertically scrolling page, the scrolling can very easily get interrupted. This is because the vertical scroller will start scrolling as soon as touch movement is going in a vertical direction. 

`RequestDisallowInterceptTouchEvent(true)` is now called as soon as the `HorizontalListview` starts scrolling, to prevent any other controls from intercepting touch events for as long as the user is scrolling.
